### PR TITLE
Perform whitespace removal (like Mojo 6) in Sanitize

### DIFF
--- a/lib/Mojolicious/Plugin/MoreUtilHelpers.pm
+++ b/lib/Mojolicious/Plugin/MoreUtilHelpers.pm
@@ -75,7 +75,13 @@ sub register {
 	@attr{@$names} = (1) x @$names if ref $names eq 'ARRAY';
 
 	my $doc = Mojo::DOM->new($html);
-	return $doc->all_text unless %tags;
+        if (! %tags) {
+	    my $txt = $doc->all_text;
+            $txt =~ s/\s+/ /g;
+            $txt =~ s/^ //;
+            $txt =~ s/ $//;
+            return $txt;
+        }
 
 	for my $node (@{$doc->descendant_nodes}) {
 	    if($node->tag && !$tags{ $node->tag }) {


### PR DESCRIPTION
I received your module as part of the November CPAN Pull Request Challenge.  I looked at the bug referenced in #3 and put together this pretty simple fix (it's very similar tot he code that was removed in Mojo 7).

Mojo 7 no longer trims or removes extra whitespace in the all_text() method call, which caused a test to fail.

There are two ways to fix it - either add the whitespace removal to the sanitize method, or change the test.  Because of concerns about breaking compatibility, I'm thinking removing the whitespace is the better option, but if you disagree, let me know and I'll submit a PR with the test changed instead.